### PR TITLE
fix(remix-article):changes remix update import data

### DIFF
--- a/app/root.jsx
+++ b/app/root.jsx
@@ -1,4 +1,4 @@
-import { Outlet, LiveReload, Link, Links, Meta } from 'remix';
+import { Outlet, LiveReload, Link, Links, Meta } from '@remix-run/react';
 
 export const links = () => [
   // Bootstrap CSS CDN

--- a/app/routes/$locale/$slug.jsx
+++ b/app/routes/$locale/$slug.jsx
@@ -1,5 +1,5 @@
 import { getArticles } from '@polyblog/polyblog-js-client';
-import { useLoaderData } from 'remix';
+import { useLoaderData } from '@remix-run/react';
 
 export const loader = async ({ params }) => {
   const { locale, slug } = params;

--- a/app/routes/$locale/index.jsx
+++ b/app/routes/$locale/index.jsx
@@ -1,5 +1,5 @@
 import { getArticles } from '@polyblog/polyblog-js-client';
-import { useLoaderData, Link } from 'remix';
+import { useLoaderData, Link } from '@remix-run/react';
 
 export const loader = async ({ params }) => {
   const locale = params.locale;

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -1,4 +1,4 @@
-import { redirect } from 'remix';
+import { redirect } from '@remix-run/server-runtime';
 
 export function loader({ request }) {
   let languageHeader = request.headers.get('accept-language');


### PR DESCRIPTION
Fixes #18 

Remix Js changes the import data path. So I change here current remix js import path.

## Changes

- root.jsx file:
 import data from 'remix' to '@remix-run/react'
- app/routes/index.jsx
 import data from 'remix' to '@remix-run/server-runtime'
- app/routes/$locale/index.jsx
 import data from 'remix' to '@remix-run/react'
- app/routes/$locale/$slug.jsx
 import data from 'remix' to '@remix-run/react';

## Screenshots

(prefer animated gif for UI interactions)

## Checklist

- [x] Linked issues on the right bar?
